### PR TITLE
Update Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.0
+// swift-tools-version:4.2
 
 import PackageDescription
 


### PR DESCRIPTION
Currently, when trying to build `SKQueue` with Swift 5.2.2 from Xcode 11.4.1, I get this error:

```
.build/checkouts/SKQueue: error: manifest parse error(s):
.build/checkouts/SKQueue/Package.swift:5:15: error: 'init(name:pkgConfig:providers:products:dependencies:targets:swiftLanguageVersions:cLanguageStandard:cxxLanguageStandard:)' 
is unavailable
let package = Package(
              ^~~~~~~
PackageDescription.Package:30:12: note: 'init(name:pkgConfig:providers:products:dependencies:targets:swiftLanguageVersions:cLanguageStandard:cxxLanguageStandard:)' 
was introduced in PackageDescription 4.2
    public init(name: String, pkgConfig: String? = nil, providers: [PackageDescription.SystemPackageProvider]? = nil, products: [PackageDescription.Product] = [], dependencies: [PackageDescription.Package.Dependency] = [], targets: [PackageDescription.Target] = [], swiftLanguageVersions: [PackageDescription.SwiftVersion]? = nil, cLanguageStandard: PackageDescription.CLanguageStandard? = nil, cxxLanguageStandard: PackageDescription.CXXLanguageStandard? = nil)
```

Bumping `swift-tools-version` in `Package.swift` to 4.2 fixes the problem.